### PR TITLE
Build with gcc 5

### DIFF
--- a/decompiler/test/codegen.h
+++ b/decompiler/test/codegen.h
@@ -51,7 +51,7 @@ public:
 	std::basic_ios<cT, traits>(&m_sbuf),
 	std::basic_ostream<cT, traits>(&m_sbuf)
 	{
-		init(&m_sbuf);
+		this->init(&m_sbuf);
 	}
 
 private:


### PR DESCRIPTION
gcc 5 can't find init() like this, it needs this->init().