### PR TITLE
AMIGAOS: Static builds preferred

### DIFF
--- a/configure
+++ b/configure
@@ -1044,7 +1044,6 @@ echo_n "Checking hosttype... "
 echo $_host_os
 case $_host_os in
 	amigaos*)
-		LDFLAGS="$LDFLAGS -use-dynld"
 		LDFLAGS="$LDFLAGS -L/sdk/local/newlib/lib"
 		# We have to use 'long' for our 4 byte typedef because AmigaOS already typedefs (u)int32
 		# as (unsigned) long, and consequently we'd get a compiler error otherwise.


### PR DESCRIPTION
I'm not sure if i'm allowed to copy the reasons from a ScummVM PR, so sorry if i broke the guidelines.

I completely forgot about the tools.
It doesn't need to delay the 1.8.0 release process and be backported, i changed it locally and will use it onward 1.8.x.

Sorry for the hassle

Reasons:

- Shared objects aren't really shared on AmigaOS. (Once two programs load the same .so, it will be available twice in memory, instead of sharing the already available one)
- To make the program run for everyone i need to provide a subdir (SObjs/) which holds all the .so's used while compiling (which are not available in a clean OS install), otherwise most people have to go hunting for the correct .so's online. Even worse is the fact that, if users have older (incompatible) .so's installed, they might experience crashes.
- There is no benefit in building the tools with shared objects (at least on AmigaOS), because even if a new lib version (i.e. libPNG) would be made available as an .so (and features new stuff), it won't be mandatory to immediately switch to it, because the tools probably won't take advantage of the new features as fast anyway. So, a rebuilt is always better (imho).

In short:
Switchting to static builds to reduce user grief, crash reports, a little less work to create the package and as a bonus have the tools start a little faster.