### PR TITLE
TOOLS: Fix V0: setBitVar can take 3 variables

### DIFF
--- a/engines/scumm/descumm.cpp
+++ b/engines/scumm/descumm.cpp
@@ -2503,7 +2503,7 @@ void next_line_V0(char *buf) {
 	case 0xBD:
 	case 0xDD:
 	case 0xFD:
-		do_tok(buf, "setBitVar", A1B | ((opcode & 0x80) ? A2V : A2B) | ((opcode & 0x40) ? A3V : A3B));
+		do_tok(buf, "setBitVar", ((opcode & 0x80) ? A1V : A1B) | ((opcode & 0x40) ? A2V : A2B) | ((opcode & 0x20) ? A3V : A3B));
 		break;
 
 	case 0x1B:


### PR DESCRIPTION
Currently certain calls to setBitVar are outputting (script-42 V0 / script-6 v0 demo)
[079A] (9D) setBitVar(4,VAR_RESULT,0);

when it should be
[079A] (9D) setBitVar(VAR_ROOM,1,0);