### PR TITLE
CONFIGURE: Ignore options valid for Autotools configure

### DIFF
--- a/configure
+++ b/configure
@@ -429,6 +429,21 @@ done # for parm in ...
 
 for ac_option in $@; do
 	case "$ac_option" in
+	# Silently ignore options valid for Autotools configure.
+	--build=*)                                ;;
+	--host=*)                                 ;;
+	--exec-prefix=*)                          ;;
+	--program-prefix=*)                       ;;
+	--sbindir=*)                              ;;
+	--sysconfdir=*)                           ;;
+	--includedir=*)                           ;;
+	--libexecdir=*)                           ;;
+	--localstatedir=*)                        ;;
+	--sharedstatedir=*)                       ;;
+	--infodir=*)                              ;;
+	--disable-dependency-tracking)            ;;
+	--enable-dependency-tracking)             ;;
+	# End of ignored options.
 	--enable-vorbis)          _vorbis=yes     ;;
 	--disable-vorbis)         _vorbis=no      ;;
 	--enable-tremor)          _tremor=yes     ;;


### PR DESCRIPTION
RPM-based distributions come with a configure macro, that sets up the whole build environment.  In order to be able to use this macro, some options, which are valid for the configure script generated by GNU Autotools, should not error-out when preparing the build stage.

Backported (and slightly modified) from scummvm/scummvm@826b7bfe.

See https://github.com/scummvm/scummvm/pull/2079 for further reference.