### PR TITLE
Revert "CONFIGURE: Ignore options valid for Autotools configure"

### DIFF
--- a/configure
+++ b/configure
@@ -429,21 +429,6 @@ done # for parm in ...
 
 for ac_option in $@; do
 	case "$ac_option" in
-	# Silently ignore options valid for Autotools configure.
-	--build=*)                                ;;
-	--host=*)                                 ;;
-	--exec-prefix=*)                          ;;
-	--program-prefix=*)                       ;;
-	--sbindir=*)                              ;;
-	--sysconfdir=*)                           ;;
-	--includedir=*)                           ;;
-	--libexecdir=*)                           ;;
-	--localstatedir=*)                        ;;
-	--sharedstatedir=*)                       ;;
-	--infodir=*)                              ;;
-	--disable-dependency-tracking)            ;;
-	--enable-dependency-tracking)             ;;
-	# End of ignored options.
 	--enable-vorbis)          _vorbis=yes     ;;
 	--disable-vorbis)         _vorbis=no      ;;
 	--enable-tremor)          _tremor=yes     ;;


### PR DESCRIPTION
This reverts commit 7a68e7088dfbcd18868ecceec58cbfbf9ef6e89a.

See: https://github.com/scummvm/scummvm-tools/commit/7a68e7088dfbcd18868ecceec58cbfbf9ef6e89a#commitcomment-37478213

TL;DR: Breaks cross-compiling, CXX ignored, --host ignored.