### PR TITLE
TINSEL: fix FLAC package creation

### DIFF
--- a/engines/tinsel/compress_tinsel.cpp
+++ b/engines/tinsel/compress_tinsel.cpp
@@ -287,7 +287,7 @@ void CompressTinsel::execute() {
 		_output_smp.writeUint32BE(MKID_BE('OGG '));
 		break;
 	case AUDIO_FLAC:
-		_output_idx.writeUint32BE(MKID_BE('FLAC'));
+		_output_smp.writeUint32BE(MKID_BE('FLAC'));
 		break;
 	default:
 		throw ToolException("Unknown audio format!");

--- a/engines/tinsel/compress_tinsel.cpp
+++ b/engines/tinsel/compress_tinsel.cpp
@@ -348,6 +348,11 @@ void CompressTinsel::execute() {
 		indexNo++;
 	}
 
+	/* Close file handles */
+	_output_smp.close();
+	_output_idx.close();
+	_input_smp.close();
+	_input_idx.close();
 	/* And some clean-up :-) */
 	Common::removeFile(TEMP_RAW);
 	Common::removeFile(TEMP_ENC);


### PR DESCRIPTION
Fixes a minor error with FLAC package creation with the compress_tinsel tool. (960031b)

Also closes the input/output files at an appropriate time (for all compression types). Previously the output files were not saved until the ScummVM tools GUI was closed. (0c953fe)