### PR TITLE
SCUMM: Fully encrypt resulting files from C64 disk images, fixes bug#12303

### DIFF
--- a/engines/scumm/extract_mm_c64.cpp
+++ b/engines/scumm/extract_mm_c64.cpp
@@ -137,6 +137,7 @@ void ExtractMMC64::execute() {
 		sprintf(fname, "%02i.LFL", i);
 		outpath.setFullName(fname);
 		output.open(outpath, "wb");
+		output.setXorMode(0xFF);
 
 		print("Creating %s...", fname);
 		input->seek((SectorOffset[room_tracks[i]] + room_sectors[i]) * 256, SEEK_SET);

--- a/engines/scumm/extract_zak_c64.cpp
+++ b/engines/scumm/extract_zak_c64.cpp
@@ -139,6 +139,7 @@ void ExtractZakC64::execute() {
 		sprintf(fname, "%02i.LFL", i);
 		outpath.setFullName(fname);
 		output.open(outpath, "wb");
+		output.setXorMode(0xFF);
 
 		print("Creating %s...", fname);
 		input->seek((SectorOffset[room_tracks_c64[i]] + room_sectors_c64[i]) * 256, SEEK_SET);


### PR DESCRIPTION
The data on the .d64 images is not XORed.
The c64 extraction tool XORs only room 0 (index) with 0xFF
ScummVM expects all files to be XORed with 0xFF

With this patch all files are XORed, which is what ScummVM expects.

Fixes bug#12303