### PR TITLE
SCUMM: Fix missing return values in HE games

### DIFF
--- a/engines/scumm/descumm6.cpp
+++ b/engines/scumm/descumm6.cpp
@@ -2019,7 +2019,7 @@ void next_line_HE_V100(char *output) {
 		ext(output, "hh|renameFile");
 		break;
 	case 0x66:
-		ext(output, "|stopObjectCode");
+		ext(output, "p|return");
 		break;
 	case 0x67:
 		ext(output, "p|localizeArrayToRoom");
@@ -2609,7 +2609,7 @@ void next_line_HE_V100(char *output) {
 		ext(output, "lpp|startObjectQuick");
 		break;
 	case 0xDE:
-		ext(output, "lp|startScriptQuick2");
+		ext(output, "rlp|startScriptQuick2");
 		break;
 	case 0xDF:
 		ext(output, "rp|getState");
@@ -3708,7 +3708,7 @@ void next_line_HE_V72(char *output) {
 				"\xCCv|nukeArray");
 		break;
 	case 0xBD:
-		ext(output, "|stopObjectCode");
+		ext(output, "p|return");
 		break;
 	case 0xBE:
 		// TODO: this loads another script which does something like
@@ -3720,7 +3720,7 @@ void next_line_HE_V72(char *output) {
 		ext(output, "lpp|startObjectQuick");
 		break;
 	case 0xBF:
-		ext(output, "lp|startScriptQuick2");
+		ext(output, "rlp|startScriptQuick2");
 		break;
 	case 0xC0:
 		ext(output, "x" "dim2dimArray\0"
@@ -5340,7 +5340,7 @@ void next_line_V67(char *output) {
 		break;
 	case 0xBD:
 		if (g_options.heVersion)
-			ext(output, "|stopObjectCode");
+			ext(output, "p|return");
 		else
 			invalidop(NULL, code);
 		break;
@@ -5354,7 +5354,7 @@ void next_line_V67(char *output) {
 		ext(output, "lpp|startObjectQuick");
 		break;
 	case 0xBF:
-		ext(output, "lp|startScriptQuick2");
+		ext(output, "rlp|startScriptQuick2");
 		break;
 	case 0xC0:
 		ext(output, "x" "dim2dimArray\0"


### PR DESCRIPTION
Fixes missing return expressions from some scripts,
and the matching assignment of the return value on caller

for example
```
Script# 2136
[0000] (43) localvar1 = ((var281 + var284) / 1000)
[000E] (43) localvar2 = ((var283 + var286) / 1000)
[001C] (BD) stopObjectCode()
[0035] (66) stopObjectCodeB()
END
```

becomes
```
Script# 2136
[0000] (43) localvar1 = ((var281 + var284) / 1000)
[000E] (43) localvar2 = ((var283 + var286) / 1000)
[001C] (BD) return(getDistanceBetweenPoints.case28(array266[localvar0][0],array266[localvar0][2],localvar1,localvar2))
[0035] (66) stopObjectCodeB()
END
```
which reveals much more information.

and caller:
```
Script# 2148
[0000] (5D) if (localvar1 < ((localvar2 + localvar3) + 12)) {
[0011] (5D)   if (var462 == 2) {
[001A] (43)     localvar6 = 100
[001F] (73)   } else {
[0022] (43)     localvar6 = 200
[0027] (**)   }
[0027] (BF)   startScriptQuick2(2066,[roomarray3[(localvar0 - 37)]])
ERROR: No items on stack to pop!
[003A] (5D)   if (**** INVALID DATA **** < getRandomNumber(localvar6)) {
[003E] (BF)     startScriptQuick2(2136,[localvar0])
ERROR: No items on stack to pop!
[0047] (43)     localvar5 = **** INVALID DATA ****
[004A] (5D)     if (localvar5 > ((localvar1 + localvar3) + 12)) {
[005B] (BD)       stopObjectCode()
[005E] (**)     }
[005E] (**)   }
[005E] (**) }
[005E] (BD) stopObjectCode()
[0062] (66) stopObjectCodeB()
END
```
becomes:
```Script# 2148
[0000] (5D) if (localvar1 < ((localvar2 + localvar3) + 12)) {
[0011] (5D)   if (var462 == 2) {
[001A] (43)     localvar6 = 100
[001F] (73)   } else {
[0022] (43)     localvar6 = 200
[0027] (**)   }
[0027] (5D)   if (getRandomNumber(localvar6) < startScriptQuick2(2066,[roomarray3[(localvar0 - 37)]])) {
[003E] (43)     localvar5 = startScriptQuick2(2136,[localvar0])
[004A] (5D)     if (localvar5 > ((localvar1 + localvar3) + 12)) {
[005B] (BD)       return(1)
[005E] (**)     }
[005E] (**)   }
[005E] (**) }
[005E] (BD) return(localvar4)
[0062] (66) stopObjectCodeB()
END
```

I'm pretty sure the same should be applied to `startObjectQuick` but there is explicit comment saying it shouldn't so better check it more.