### PR TITLE
TOOLS: pack_bladerunner Remove CDFRAMES.DAT 'missing' warning

### DIFF
--- a/README
+++ b/README
@@ -470,12 +470,10 @@ Other Tools:
         pack_bladerunner
                 Used to combine Blade Runner CDFRAMES.DAT files into HDFRAMES.DAT.
 
-                1. Copy CDFRAMES.DAT file from CD1 to some directory.
+                1. Copy CDFRAMES.DAT files from CDs 1-4 to the same directory
+                but name them CDFRAMES1.DAT - CDFRAMES4.DAT respectively.
 
-                2. Copy CDFRAMES.DAT files from CDs 2-4 to the same directory
-                but name them CDFRAMES2.DAT - CDFRAMES4.DAT respectively.
+                2. Run the tool:
+                  ./scummvm-tools-cli --tool pack_bladerunner [-o outputfile] <inputdir>/CDFRAMES1.DAT
 
-                3. Run the tool:
-                  ./scummvm-tools-cli --tool pack_bladerunner [-o outputfile] <inputdir>/CDFRAMES.DAT
-
-                4. Copy the resulting HDFRAMES.DAT file to the game directory.
+                3. Copy the resulting HDFRAMES.DAT file to the game directory.

--- a/engines/bladerunner/pack_bladerunner.cpp
+++ b/engines/bladerunner/pack_bladerunner.cpp
@@ -69,10 +69,8 @@ void PackBladeRunner::execute() {
 
 	mainDir.setFullName("CDFRAMES.DAT");
 	if (!mainDir.exists()) {
-		warning("Could not find file %s", mainDir.getName().c_str());
 		snprintf(fname, 20, "CDFRAMES%d.DAT", curCD);
 		mainDir.setFullName(fname);
-		warning("Retrying for file %s", mainDir.getName().c_str());
 	}
 	in.open(mainDir, "rb");
 


### PR DESCRIPTION
- Removed warning about CDFRAMES.DAT missing as only a problem if CDFRAMES1.DAT is missing (and it already warns on that)
- Simplify documentation to match and remove a step
- Does not change actual code behavior, should be 100% non-breaking

This standardizes the tool use and docs to be in sync around the naming of the CDFRAMES1.DAT file.
About half the wiki/documentation already recommended naming the first file CDFRAMES1.DAT and this makes copying the game files easier.

The actual code behavior does not change (still checks for CDFRAMES.DAT before falling back to CDFRAMES1.DAT) so should be 100% non breaking.

If preferred can re-write the code/warning to try CDFRAMES1.DAT and then warn if not found and try CDFRAMES.DAT after.