### PR TITLE
CONFIGURE: Suppress format warnings in AmigaOS

### DIFF
--- a/configure
+++ b/configure
@@ -1182,11 +1182,13 @@ echo_n "Checking hosttype... "
 echo $_host_os
 case $_host_os in
 	amigaos*)
-		LDFLAGS="$LDFLAGS -L/sdk/local/newlib/lib"
-		# We have to use 'long' for our 4 byte typedef because AmigaOS already typedefs (u)int32
-		# as (unsigned) long, and consequently we'd get a compiler error otherwise.
-		type_4_byte='long'
 		add_line_to_config_mk 'AMIGAOS = 1'
+		LDFLAGS="$LDFLAGS -L/sdk/local/newlib/lib"
+		# Use 'long' for ScummVM's 4 byte typedef, because AmigaOS
+		# already typedefs (u)int32 as (unsigned) long and suppress
+		# those noisy format warnings caused by the 'long' 4 byte
+		type_4_byte='long'
+		append_var CXXFLAGS "-Wno-format"
 		;;
 	beos*)
 		DEFINES="$DEFINES -DSYSTEM_NOT_SUPPORTING_D_TYPE"


### PR DESCRIPTION
Warnings go down a fair bit with this