### PR TITLE
GOB: Fix an unused variable warning on BE targets

### DIFF
--- a/engines/gob/extract_gob_cdi.cpp
+++ b/engines/gob/extract_gob_cdi.cpp
@@ -67,8 +67,8 @@ typedef struct {
 #include "common/pack-end.h"
 
 void fix_entry_endianess(rtf_entry *entry) {
-	Uint32 data;
 #ifdef SCUMM_LITTLE_ENDIAN
+	Uint32 data;
 	data = entry->offset;
 	data = ((data >> 24) & 0x000000FF) |
 		((data >> 8) & 0x0000FF00) |


### PR DESCRIPTION
Please review as i'm not sure this is the correct approach.

I'm on BE and this triggers an unused variable warning.
Since it looks as if it's only used on LE targets it should probably be inside the #ifdef clause?

Warning is gone locally, but i cannot test LE targets