### PR TITLE
CONFIGURE: (AMIGAOS) Fix undefined references

### DIFF
--- a/configure
+++ b/configure
@@ -1572,18 +1572,6 @@ fi
 define_in_config_if_yes "$_flac" 'USE_FLAC'
 echo "$_flac"
 
-# AmigaOS has it's latest FLAC port (1.4.2) compiled with -fstack-protector
-# This leads to linker errors in "scummvm-tools-cli" due to
-# undefined references to '__stack_check_fail'
-# Using -lssp to fix that
-case $_host_os in
-	amigaos*)
-		if test "$_flac" = yes ; then
-			LIBS="$LIBS -lssp"
-		fi
-	;;
-esac
-
 #
 # Check for MAD (MP3 library)
 #

--- a/configure
+++ b/configure
@@ -1571,6 +1571,18 @@ fi
 define_in_config_if_yes "$_flac" 'USE_FLAC'
 echo "$_flac"
 
+# AmigaOS has it's latest FLAC port (1.4.2) compiled with -fstack-protector
+# This leads to linker errors in "scummvm-tools-cli" due to
+# undefined references to '__stack_check_fail'
+# Using -lssp to fix that
+case $_host_os in
+	amigaos*)
+		if test "$_flac" = yes ; then
+			LIBS="$LIBS -lssp"
+		fi
+	;;
+esac
+
 #
 # Check for MAD (MP3 library)
 #

--- a/configure
+++ b/configure
@@ -1183,12 +1183,13 @@ echo $_host_os
 case $_host_os in
 	amigaos*)
 		add_line_to_config_mk 'AMIGAOS = 1'
-		LDFLAGS="$LDFLAGS -L/sdk/local/newlib/lib"
 		# Use 'long' for ScummVM's 4 byte typedef, because AmigaOS
 		# already typedefs (u)int32 as (unsigned) long and suppress
 		# those noisy format warnings caused by the 'long' 4 byte
 		type_4_byte='long'
 		CXXFLAGS="$CXXFLAGS -Wno-format"
+		# Dependencies might also be compiled with stack protection
+		LDFLAGS="$LDFLAGS -L/sdk/local/newlib/lib -fstack-protector"
 		;;
 	beos*)
 		DEFINES="$DEFINES -DSYSTEM_NOT_SUPPORTING_D_TYPE"


### PR DESCRIPTION
AmigaOS recently got an updated libFLAC (1.4.2) which was compiled with -fstack-protector (thank you @sev-  for clearing that up)

Compiling scummvm-tools now lead to numerous undefined references to __stack_chk_fail. Hence using -lssp which fixes the errors and compiles working binaries again.

I don't know if this is the right approach or if there would be a better solution, so please advise

Thank you