### PR TITLE
MISC: copy .editorconfig, .clang-tidy, and .gitattributes from scummvm

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,8 @@
+---
+Checks:          'clang-diagnostic-*,clang-analyzer-*,performance-*,portability-*,bugprone-*'
+CheckOptions:
+  - key:   readability-identifier-naming.MethodCase
+    value: camelBack
+  - key:   readability-identifier-naming.ParameterCase
+    value: camelBack
+...

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+[*]
+indent_style = tab
+indent_size = 4
+trim_trailing_whitespace = true
+insert_final_newline = true
+vc_generate_documentation_comments = doxygen_slash_star
+end_of_line = lf
+
+[*.bat]
+end_of_line = crlf
+
+[*.lingo]
+charset = macroman

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,10 @@
+/po/*.po encoding=utf-8
+*.lingo	encoding=MacRoman
+/engines.awk eol=lf
+*.bat text eol=crlf
+*.cpp text eol=lf
+*.h text eol=lf
+*.hpp text eol=lf
+*.sh text eol=lf
+/config* text eol=lf
+configure.engine text eol=lf


### PR DESCRIPTION
I know some of the .gitattributes rules don't affect this repo, but I think it's easier to keep the files in sync when they're completely identical and you don't have to worry about it

will need to squash merge cause I didn't do the commit message correctly lol, I was doing this to see if Github Actions would run