### PR TITLE
JANITORIAL: Fix typos in tools

### DIFF
--- a/common/ptr.h
+++ b/common/ptr.h
@@ -264,7 +264,7 @@ public:
 	}
 
 	/**
-	 * Checks if the object is the only object refering
+	 * Checks if the object is the only object referring
 	 * to the assigned pointer. This should just be used for
 	 * debugging purposes.
 	 */

--- a/common/scummsys.h
+++ b/common/scummsys.h
@@ -196,7 +196,7 @@
 	// This is done for two reasons
 	// a) uint is already defined by Symbians libc component
 	// b) Symbian is using its "own" datatyping, and the Scummvm port
-	//    should follow this to ensure the best compability possible.
+	//    should follow this to ensure the best compatibility possible.
 	#define SCUMMVM_DONT_DEFINE_TYPES
 	typedef unsigned char byte;
 

--- a/common/str.h
+++ b/common/str.h
@@ -34,7 +34,7 @@
 namespace Common {
 
 /**
- * Simple string class for ScummVM. Provides automatic storage managment,
+ * Simple string class for ScummVM. Provides automatic storage management,
  * and overloads several operators in a 'natural' fashion, mimicking
  * the std::string class. Even provides simple iterators.
  *

--- a/common/stream.cpp
+++ b/common/stream.cpp
@@ -423,7 +423,7 @@ bool BufferedSeekableReadStream::seek(int64 offset, int whence) {
 		if (whence == SEEK_CUR)
 			offset -= (_bufSize - _pos);
 		// We invalidate the buffer here. This assures that successive seeks
-		// do not have the chance to incorrectly think they seeked back into
+		// do not have the chance to incorrectly think they seek'd back into
 		// the buffer.
 		// Note: This does not take full advantage of the buffer. But it is
 		// a simple way to prevent nasty errors. It would be possible to take

--- a/convert_dxa.bat
+++ b/convert_dxa.bat
@@ -35,7 +35,7 @@ goto :eof
 :check_bink
 if exist "%BINK_PATH%\binkconv.exe" goto :preencode
 echo.
-echo Bink convertion tool cannot be found!
+echo Bink conversion tool cannot be found!
 goto :eof
 
 :preencode

--- a/create_sjisfnt.cpp
+++ b/create_sjisfnt.cpp
@@ -557,7 +557,7 @@ void Glyph::convertChar16x16(uint8 *dst) const {
 }
 
 void fixYOffset(GlyphList &glyphs) {
-	// We try to find the minimum y offset here so we can substract it to make it 0 in the end.
+	// We try to find the minimum y offset here so we can subtract it to make it 0 in the end.
 	// We need to do this, since otherwise the characters will take up too much vertical space.
 	int minYOffset = 0xFFFF;
 

--- a/decompiler/doc/overview.tex
+++ b/decompiler/doc/overview.tex
@@ -25,7 +25,7 @@ int main(int argc, char **argv) {
 \end{lstlisting}
 \end{C++}
 
-In this document, the terms \emph{control flow analysis} and \emph{code flow analysis} are used interchangably.
+In this document, the terms \emph{control flow analysis} and \emph{code flow analysis} are used interchangeably.
 
 \subsection{Limitations}
 The decompiler is targeted for stack-based instruction sets, and may contain assumptions to that effect. If you want to add an engine which does not use a stack-based instruction set, parts of this document may not apply directly, and additional work to the generic parts may be necessary.

--- a/decompiler/doc/todo.tex
+++ b/decompiler/doc/todo.tex
@@ -10,7 +10,7 @@ Currently, only unconditional jumps are allowed for break/continue. However, whe
 
 Support for this should be added to the analysis. Should be doable by also checking destinations of unmarked conditional jumps, since ifs are marked after breaks and continues - so simply add that to the initial filter and make sure we process the right (non-sequential) target vertex.
 
-Classifying as an enhancement since it appears this optimization is not used in SCUMMv6 (there is an if (...) break in tentacle/room-13-206, but the break is a separate jump). Not sure if KYRA uses it - a cursory scan of the KYRA2 demo suggests that it could use an optimization, as I found only 1 occurence of a c1\_ifNotJmp immediately followed by a c1\_jump (skull\textbackslash skull.emc, 0x0578) - but it did not look like a loop. That, however, does not prove that KYRA actually uses the optimization - it could simply be that such a piece of code was never used.
+Classifying as an enhancement since it appears this optimization is not used in SCUMMv6 (there is an if (...) break in tentacle/room-13-206, but the break is a separate jump). Not sure if KYRA uses it - a cursory scan of the KYRA2 demo suggests that it could use an optimization, as I found only 1 occurrence of a c1\_ifNotJmp immediately followed by a c1\_jump (skull\textbackslash skull.emc, 0x0578) - but it did not look like a loop. That, however, does not prove that KYRA actually uses the optimization - it could simply be that such a piece of code was never used.
 
 As far as I have been able to tell, this optimization really is not used in Kyra, so this will have to be deferred until we have an engine which needs it.
 

--- a/dists/win32/scummvm-tools.nsi
+++ b/dists/win32/scummvm-tools.nsi
@@ -64,7 +64,7 @@ Name "ScummVM Tools"
 !define COMPANY     "ScummVM Team"
 !define URL         "https://www.scummvm.org/"
 !define DESCRIPTION "ScummVM Tools Installer. Look! A three headed monkey (TM)!"
-!define COPYRIGHT   "Copyright © 2001-2023 The ScummVM Team"
+!define COPYRIGHT   "Copyright Â© 2001-2023 The ScummVM Team"
 
 #########################################################################################
 # Installer configuration
@@ -72,7 +72,7 @@ Name "ScummVM Tools"
 OutFile          ${build_dir}\scummvm-tools-${VERSION}-${ARCH}.exe
 InstallDir       $PROGRAMFILES\ScummVM\tools                             ; Default installation folder
 InstallDirRegKey HKCU "Software\ScummVM\ScummVM Tools" "InstallPath"    ; Get installation folder from registry if available
-                                                                        ; The application name needs to be refered directly instead of through ${REGKEY}
+                                                                        ; The application name needs to be referred to directly instead of through ${REGKEY}
                                                                         ; because lang strings aren't initialized at the point InstallDirRegKey is called
 
 CRCCheck on

--- a/dists/win32/scummvm-tools.nsi.in
+++ b/dists/win32/scummvm-tools.nsi.in
@@ -64,7 +64,7 @@ Name "ScummVM Tools"
 !define COMPANY     "ScummVM Team"
 !define URL         "https://www.scummvm.org/"
 !define DESCRIPTION "ScummVM Tools Installer. Look! A three headed monkey (TM)!"
-!define COPYRIGHT   "Copyright © 2001-2023 The ScummVM Team"
+!define COPYRIGHT   "Copyright Â© 2001-2023 The ScummVM Team"
 
 #########################################################################################
 # Installer configuration
@@ -72,7 +72,7 @@ Name "ScummVM Tools"
 OutFile          ${build_dir}\scummvm-tools-${VERSION}-${ARCH}.exe
 InstallDir       $PROGRAMFILES\ScummVM\tools                             ; Default installation folder
 InstallDirRegKey HKCU "Software\ScummVM\ScummVM Tools" "InstallPath"    ; Get installation folder from registry if available
-                                                                        ; The application name needs to be refered directly instead of through ${REGKEY}
+                                                                        ; The application name needs to be referred to directly instead of through ${REGKEY}
                                                                         ; because lang strings aren't initialized at the point InstallDirRegKey is called
 
 CRCCheck on

--- a/engines/director/patterns/qtvr.hexpat
+++ b/engines/director/patterns/qtvr.hexpat
@@ -137,7 +137,7 @@ struct UnknownAtomSelector {
     Atom atom_header [[hidden]];
     $ = addressof(this);
     UnknownAtom unknown [[name(atom_header.box_type)]];
-    std::print("unkown: " + atom_header.box_type);
+    std::print("unknown: " + atom_header.box_type);
 } [[inline]];
 
 struct UnknownAtom : Atom {
@@ -160,7 +160,7 @@ struct UnknownAtom : Atom {
     } else {
         $ = next_offset;
     }
-    std::print("unkown atom: {}: {}", box_type, $);
+    std::print("unknown atom: {}: {}", box_type, $);
 } [[format("format_box_type")]];
 
 fn format_box_type(auto box) {

--- a/engines/grim/docs/ResidualVM-Patch.txt
+++ b/engines/grim/docs/ResidualVM-Patch.txt
@@ -59,8 +59,8 @@ Offset	Size	Var
 6		2		VersionMinor <= 0
 8		4		flags
 12		16		md5sum of old file
-28		4		lenght of old file
-32		4		lenght of new file
+28		4		length of old file
+32		4		length of new file
 36		4		length of gzipped ctrl block (x)
 40		4		length of gzipped diff block (y)
 44		4		length of gzipped extra block (z) (if zero the extra block is missing or mixed with diff block)

--- a/engines/grim/lua/lmem.cpp
+++ b/engines/grim/lua/lmem.cpp
@@ -81,7 +81,7 @@ void *luaM_realloc (void *block, int32 size)
   int32 realsize = HEADER+size+1;
   if (realsize != (size_t)realsize)
     lua_error("Allocation Error: Block too big");
-  if (size == 0) {  /* ANSI dosen't need this, but some machines... */
+  if (size == 0) {  /* ANSI doesn't need this, but some machines... */
     if (block) {
       int32 *b = (int32 *)((char *)block - HEADER);
       memset(block, -1, *b);  /* erase block */

--- a/engines/grim/patchex/patchex.cpp
+++ b/engines/grim/patchex/patchex.cpp
@@ -212,7 +212,7 @@ static struct mspack_system res_system = {
 	&res_tell, NULL
 };
 
-void extract_cabinet(char *filename, unsigned int lenght) {
+void extract_cabinet(char *filename, unsigned int length) {
 	struct mspack_file *original_executable, *destination_cabinet;
 	void *buffer;
 	unsigned int copied_bytes, remBytes;
@@ -224,8 +224,8 @@ void extract_cabinet(char *filename, unsigned int lenght) {
 	buffer = malloc(BUFFER_SIZE);
 	copied_bytes = 0;
 
-	while (copied_bytes < lenght) {
-		remBytes = lenght - copied_bytes;
+	while (copied_bytes < length) {
+		remBytes = length - copied_bytes;
 		count = res_read(original_executable, buffer, (remBytes < BUFFER_SIZE) ? remBytes : BUFFER_SIZE);
 		writeResult = res_write(destination_cabinet, buffer, count);
 		copied_bytes  += count;

--- a/engines/petka/p12explore.py
+++ b/engines/petka/p12explore.py
@@ -632,7 +632,7 @@ class App(TkBrowser):
                             format(flc.width, flc.height, \
                                 flc.frame_num, flc.delay))
                 else:
-                    self.add_info("No information availiable")
+                    self.add_info("No information available")
             except:
                 self.add_info("Error loading {} - \"{}\" \n\n{}".\
                     format(res_id, hlesc(fn), hlesc(traceback.format_exc())))

--- a/engines/petka/petka/engine.py
+++ b/engines/petka/petka/engine.py
@@ -588,8 +588,8 @@ class Engine:
                         act.num_dlgs = num_dlgs
                         if not noobjref:
                             if ref not in self.obj_idx:
-                                raise EngineError("Dialog group 0x{:x} refered "\
-                                    "to unexisted object 0x{:x}".format(
+                                raise EngineError("Dialog group 0x{:x} referred "\
+                                    "to unexisting object 0x{:x}".format(
                                     grp.idx, ref))
                             act.obj = self.obj_idx[act.ref]
                         grp.acts.append(act)

--- a/engines/prince/pack_prince.cpp
+++ b/engines/prince/pack_prince.cpp
@@ -57,7 +57,7 @@ void PackPrince::execute() {
 	_fFiles.print("credits_translate.dat\n");
 
 
-	// Export files infomation
+	// Export files information
 	int posOfFilesInformation = _fFiles.pos();
 	FileEntry filesInfo[5];
 	int fileNr = 0;

--- a/engines/sci/attic/util.h
+++ b/engines/sci/attic/util.h
@@ -24,7 +24,7 @@
 
 #include "common/scummsys.h"
 
-/* An excercise in bloated macro writing ;-)*/
+/* An exercise in bloated macro writing ;-)*/
 
 /*Declare a flexarray type*/
 #define FLEXARRAY(type, extra) struct{\

--- a/engines/sci/compress_sci.cpp
+++ b/engines/sci/compress_sci.cpp
@@ -98,7 +98,7 @@ SciResourceDataType CompressSci::detectData(byte *header, bool compressMode) {
 	if (memcmp(buffer, "\x8d\x0bSOL\x00", 6) == 0) {
 		// SOL files begin with
 		// 0x8D 0x0B/0x0C "SOL" 0x00 [samplerate:WORD] [flags:BYTE] [size of following data after header:DWORD]
-		//  0x0C variant have an additional byte inbetween data and [size of]
+		//  0x0C variant have an additional byte between data and [size of]
 		_input.read_throwsOnError(&buffer[6], 7);
 		dataSize = READ_LE_UINT32(buffer + 9);
 		_inputEndOffset = _inputOffset + 13 + dataSize;

--- a/engines/sci/compress_sci.cpp
+++ b/engines/sci/compress_sci.cpp
@@ -72,7 +72,7 @@ SciResourceDataType CompressSci::detectData(byte *header, bool compressMode) {
 	}
 	byte buffer[20];
 	memcpy(&buffer, header, 6);
-	// Fixup for pharkas resource.sfx, several WAVE files contain a size thats not right (-1 byte)
+	// Fixup for pharkas resource.sfx, several WAVE files contain a size that's not right (-1 byte)
 	int offset = 0;
 	if (memcmp(buffer + 1, "RIFF", 4) == 0) {
 		offset = 5;

--- a/gui/main.cpp
+++ b/gui/main.cpp
@@ -378,7 +378,7 @@ void ScummToolsFrame::onIdle(wxIdleEvent &evt) {
 	if (_pages.back()->onIdle(dynamic_cast<wxPanel *>(_wizardpane->FindWindow(wxT("Wizard Page"))))) {
 		// We want more!
 		evt.RequestMore(true);
-		// This way we don't freeze the OS with continous events
+		// This way we don't freeze the OS with continuous events
 		wxMilliSleep(10);
 	}
 }

--- a/gui/main.h
+++ b/gui/main.h
@@ -221,7 +221,7 @@ protected:
 	wxButton *_prefs;
 	/** 'Cancel' button. */
 	wxButton *_cancel;
-	/** The static text on the line seperating the page area and the buttons. */
+	/** The static text on the line separating the page area and the buttons. */
 	wxStaticText *_linetext;
 	/** Current page, required for dumping events to it. */
 	WizardPage *_currentPage;

--- a/version.cpp
+++ b/version.cpp
@@ -48,7 +48,7 @@
  * header file, analog to internal_version.h, maybe called svn_rev.h or so.)
  *
  * Drawback: This only works on systems which can run suitable scripts as part
- * of the build proces (so I guess Visual C++ would be out of the game here?
+ * of the build process (so I guess Visual C++ would be out of the game here?
  * I don't know VC enough to be sure). And of course it must be robust enough
  * to properly work in exports (i.e. release tar balls etc.).
  */


### PR DESCRIPTION
I don't know how i can undo the utf-8 change to the (c) symbol...github did it without my consent (just a message that it will be changed...no matter what)