### PR TITLE
CONFIGURE: Sync architecture names listed from scummvm configure

### DIFF
--- a/configure
+++ b/configure
@@ -1175,7 +1175,7 @@ test $TMPR -eq 0 || exit 1	# check exit code of subshell
 # for the smaller sizes.
 echo_n "Alignment required... "
 case $_host_cpu in
-	i[3-6]86 | x86_64 | ppc*)
+	i[3-6]86 | amd64 | x86_64 | powerpc* | ppc*)
 		# Unaligned access should work
 		_need_memalign=no
 		;;


### PR DESCRIPTION
Sync the listed architectures for the _need_memalign=no case. The
names amd64 and powerpc are used in triples for *BSD.