### PR TITLE
PRINCE: Fix deprecated construct in po-parse script

### DIFF
--- a/engines/prince/gen-translations.sh
+++ b/engines/prince/gen-translations.sh
@@ -1,6 +1,15 @@
 #! /bin/bash
 
-cp -v ../../../scummvm/devtools/create_prince/en.po .
+set -e
+
+translations_dir="$1"
+if [ -z "$translations_dir" ] || [ ! -d "$translations_dir" ]; then
+  echo "Usage: $0 <path-to-scummvm-game-translations>" >&2
+  echo "Download or clone from https://github.com/scummvm/game-translations/tree/prince-and-the-coward" >&2
+  exit 1
+fi
+
+cp -v "$translations_dir"/en.po .
 perl po-parse.pl en en.po
 ../../scummvm-tools-cli --tool pack_prince .
 cp -v prince_translation.dat ../../../scummvm/dists/engine-data/

--- a/engines/prince/po-parse.pl
+++ b/engines/prince/po-parse.pl
@@ -136,7 +136,7 @@ sub process_inv($) {
 
 	print OUT "invtxt.dat\nitemNr. name - exam text\n";
 
-	for my $n (sort {$a<=>$b} keys $data1{'invtxt.txt'}) {
+	for my $n (sort {$a<=>$b} keys %{$data1{'invtxt.txt'}}) {
 		print OUT "$n. $data1{'invtxt.txt'}{$n}\n";
 	}
 
@@ -150,7 +150,7 @@ sub process_varia($) {
 
 	print OUT "variatxt.dat\nstringId. string\n";
 
-	for my $n (sort {$a<=>$b} keys $data1{'variatxt.txt'}) {
+	for my $n (sort {$a<=>$b} keys %{$data1{'variatxt.txt'}}) {
 		print OUT "$n. $data1{'variatxt.txt'}{$n}\n";
 	}
 
@@ -166,7 +166,7 @@ sub process_mob($) {
 
 	my $pn = 0;
 
-	for my $n (sort {$a<=>$b} keys $data1{'mob.lst'}) {
+	for my $n (sort {$a<=>$b} keys %{$data1{'mob.lst'}}) {
 		my $p1 = int($n / 1000);
 
 		if ($p1 != $pn) {
@@ -197,7 +197,7 @@ sub process_talk($) {
 	for my $f (sort grep /^dialog/, keys %data1) {
 		$f =~ /dialog(\d+)/;
 		my $dialog = $1;
-		my $hasDialog = !!grep { $_ > 100 } keys $data1{$f};
+		my $hasDialog = !!grep { $_ > 100 } keys %{$data1{$f}};
 
 		if ($hasDialog) {
 			print OUT "\@DIALOGBOX_LINES:\n";
@@ -208,7 +208,7 @@ sub process_talk($) {
 		my $seenDialogBox = 0;
 		my $prevBox = -1;
 
-		for my $n (sort {$a<=>$b} keys $data1{$f}) {
+		for my $n (sort {$a<=>$b} keys %{$data1{$f}}) {
 			my $s = $data1{$f}{$n};
 			if ($n < 100) {
 				while ($s =~ /^P#/) {


### PR DESCRIPTION
This PR fixes a syntax error in newer Perls and modifies gen-translations.sh to expect an explicit path to the game translation directory.